### PR TITLE
ニックネームの１回目の入力が有効になるように修正

### DIFF
--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -8,6 +8,7 @@ class ResultsController < ApplicationController
   def trouble_category
     # ニックネームと性別をセッションに一時保持
     # if params[:nickname].present?
+    @result = Result.new(nickname_params)
     if params[:result][:nickname].present?
       session[:nickname] = params[:result][:nickname]
     # 悩みのカテゴリー選択ページ
@@ -52,6 +53,10 @@ class ResultsController < ApplicationController
   end
 
   private
+
+  def nickname_params
+    params.require(:result).permit(:name)
+  end
 
   # ストロングパラメータで受け取る値を制限する
   def result_params

--- a/app/controllers/results_controller.rb
+++ b/app/controllers/results_controller.rb
@@ -7,9 +7,9 @@ class ResultsController < ApplicationController
 
   def trouble_category
     # ニックネームと性別をセッションに一時保持
-    if params[:nickname].present?
-      session[:nickname] = params[:nickname]
-    # session[:gender] = params[:result][:gender]
+    # if params[:nickname].present?
+    if params[:result][:nickname].present?
+      session[:nickname] = params[:result][:nickname]
     # 悩みのカテゴリー選択ページ
       render 'results/trouble_category'
     else

--- a/app/views/results/nickname.html.erb
+++ b/app/views/results/nickname.html.erb
@@ -9,7 +9,6 @@
       <div class="p-6 column is-three-fifths is-offset-one-fifth">
         <%= f.text_field :nickname, placeholder: '例: 脳筋　太郎', class: 'input is-link is-large m-2' %>
         <div class="field is-grouped">
-
           <div class="control">
             <%= f.submit '次へ', class:'m-2 mt-6 custom-btn btn-1 submit-button button' %>
           </div>

--- a/app/views/results/trouble_category.html.erb
+++ b/app/views/results/trouble_category.html.erb
@@ -4,7 +4,7 @@
 
 <div class="radio-buttons">
   <p class='select-message'>悩みのカテゴリーを選択してください</p>
-  <%= form_with model: @result, url: trouble_select_results_path, local: true do |f| %>
+  <%= form_with url: trouble_select_results_path, local: true do |f| %>
     <div class='button-area p-3 has-text-centered'>
       <%= f.collection_radio_buttons :kind, Trouble.kinds_i18n, :first , :last do |b| %>
         <%= b.label(class: "radio-label has-text-left mt-5 mb-5 p-5") { b.radio_button(class: "radio-button radio m-5") + b.text } %>

--- a/app/views/results/trouble_select.html.erb
+++ b/app/views/results/trouble_select.html.erb
@@ -4,7 +4,7 @@
 
 <div class="radio-buttons">
   <p class='trouble-message'>悩みを選択してください</p>
-  <%= form_with model: @result, url: results_path, local: true do |f| %>
+  <%= form_with url: results_path, local: true do |f| %>
     <div class='p-6'>
       <% @troubles.each do |trouble| %>
         <div class='p-5 m-5'>


### PR DESCRIPTION
概要
- ニックネームの1回目の入力が無効になっていたので、１回目の入力が有効になるように修正
- 連続未入力で送信ボタンを押下するとエラーが発生したので修正


実装内容
resultsコントローラのtrouble_categoryアクション（ニックネームの入力値を受け取るアクション）
- １回目の入力を有効
アクション内でデータの受け取り方が違っていた
```
params[:nickname]
```
から
```
params[:result][:nickname]
```
に変更
これで１回の入力値が送信できるようになった

- 連続未入力
ストロングパラメータを使ってデータを受け取るようにした
trouble_category.html.erb の form_with の modelオプションを不要だったため削除
これで何度未入力で送信ボタン押下しても入力ページが表示されるようになった

確認
1回目の入力値の送信が有効
[![Image from Gyazo](https://i.gyazo.com/9c9cd236a39663e2282c4f2fee49105f.gif)](https://gyazo.com/9c9cd236a39663e2282c4f2fee49105f)

連続未入力の対処
[![Image from Gyazo](https://i.gyazo.com/a66bf20848ed1a394f6ef2212dc96df5.gif)](https://gyazo.com/a66bf20848ed1a394f6ef2212dc96df5)
