### PR TITLE
ローディングページのアニメーション実装

### DIFF
--- a/app/assets/stylesheets/wise_sayings.scss
+++ b/app/assets/stylesheets/wise_sayings.scss
@@ -1,38 +1,3 @@
- // TODO: ボタンのデザインを変更する可能性があるため残す リリース前に削除
- /*
- #loader-bg {
-  display: none;
-  position: fixed;
-  width: 100%;
-  height: 100%;
-  top: 0px;
-  left: 0px;
-  background: rgb(44, 10, 196);
-  z-index: 1;
-}
-#loader {
-  display: none;
-  position: fixed;
-  top: 50%;
-  left: 50%;
-  width: 200px;
-  height: 200px;
-  margin-top: -100px;
-  margin-left: -100px;
-  text-align: center;
-  color: #fff;
-  z-index: 2;
-}
-*/
-
-// body {
-//   text-align: center;
-//   font-size: 1.5rem;
-//   color: #fff;
-//   background: radial-gradient( circle 1400px at center, #6031e2 0%, #000 50%, #671d92 100% );
-//   height: 2000px;
-// }
-
 #loading{
   position: fixed;
   top: 0;
@@ -41,28 +6,6 @@
   height: 100vh;
   background: radial-gradient( circle 1000px at center, #671d92 10%, #000 90% );
   z-index: 9000;
-}
-
-.is-hide {
-  display: none;
-}
-
-// #animation{
-//   margin: 0;
-//   position: absolute;
-//   top: 50%;
-//   left: 50%;
-//   transform: translate(-50%, -50%);
-//   z-index: 9999;
-// }
-
-// #animation img{
-//   width: 50px;
-//   height: 50px;
-// }
-
-p{
-  margin-bottom: 0;
 }
 
 .loading-area {
@@ -86,11 +29,14 @@ p{
   font-size: 300%;
 }
 
-// TODO: ボタンのデザインを変更する可能性があるため残す リリース前に削除
-// body {
-//   background-image: url("back_image1.png");
-//   background-size: cover;
-//   background-repeat: no-repeat;
-//   color: white;
-//   font-size: 250%;
-// }
+.is-hide {
+  display: none;
+}
+
+.sink-area {
+  position: absolute;
+  left: 0;
+  right: 0;
+  margin: auto;
+  bottom: 15%;
+}

--- a/app/assets/stylesheets/wise_sayings.scss
+++ b/app/assets/stylesheets/wise_sayings.scss
@@ -4,7 +4,7 @@
   left: 0;
   width: 100vw;
   height: 100vh;
-  background: radial-gradient( circle 1000px at center, #671d92 10%, #000 90% );
+  background: radial-gradient( circle 1000px at center, #671d92 5%, #000 90% );
   z-index: 9000;
 }
 
@@ -14,15 +14,15 @@
 }
 
 .loading-title {
-  font-size: 300%;
+  font-size: 350%;
 }
 
 .loading-wise-saying {
-  font-size: 250%;
+  font-size: 225%;
 }
 
 .loading-person {
-  font-size: 225%;
+  font-size: 200%;
 }
 
 .loading-mesaage {
@@ -38,5 +38,22 @@
   left: 0;
   right: 0;
   margin: auto;
-  bottom: 15%;
+  bottom: 10%;
+}
+
+// ローディングアニメーション
+.rotation {
+  animation: rotation 1s infinite linear;
+  border: 7px solid rgba(255, 255, 255, 0.2);
+  border-radius: 50%;
+  border-top-color: rgba(255, 255, 255, 0.7);
+  height: 6em;
+  width: 6em;
+  margin: auto;
+}
+
+@keyframes rotation {
+  to {
+    transform: rotate(360deg);
+  }
 }

--- a/app/assets/stylesheets/wise_sayings.scss
+++ b/app/assets/stylesheets/wise_sayings.scss
@@ -39,7 +39,10 @@
   left: 0;
   width: 100vw;
   height: 100vh;
-  background-color: #484848;
+  // background-color: #484848;
+  // background-color: #a2a3f8;
+  // background: radial-gradient( circle 1000px at center, #000 50%, #671d92 90% );
+  background: radial-gradient( circle 1000px at center, #671d92 10%, #000 90% );
   z-index: 9000;
 }
 
@@ -59,6 +62,11 @@
 
 p{
   margin-bottom: 0;
+}
+
+.loading-area {
+  position: relative;
+  top: 15%;
 }
 
 .loading-title {

--- a/app/assets/stylesheets/wise_sayings.scss
+++ b/app/assets/stylesheets/wise_sayings.scss
@@ -39,26 +39,27 @@
   left: 0;
   width: 100vw;
   height: 100vh;
-  // background-color: #484848;
-  // background-color: #a2a3f8;
-  // background: radial-gradient( circle 1000px at center, #000 50%, #671d92 90% );
   background: radial-gradient( circle 1000px at center, #671d92 10%, #000 90% );
   z-index: 9000;
 }
 
-#animation{
-  margin: 0;
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  z-index: 9999;
+.is-hide {
+  display: none;
 }
 
-#animation img{
-  width: 50px;
-  height: 50px;
-}
+// #animation{
+//   margin: 0;
+//   position: absolute;
+//   top: 50%;
+//   left: 50%;
+//   transform: translate(-50%, -50%);
+//   z-index: 9999;
+// }
+
+// #animation img{
+//   width: 50px;
+//   height: 50px;
+// }
 
 p{
   margin-bottom: 0;

--- a/app/javascript/wise_saying.js
+++ b/app/javascript/wise_saying.js
@@ -1,50 +1,7 @@
-// $(function() {
-//   let h = $(window).height();
-
-//   $('#wrap').css('display','none');
-//   $('#loading ,#loader').height(h).css('display','block');
-// });
-  
-// $(window).load(function () { //全ての読み込みが完了したら実行
-//   $('#loading').delay(900).fadeOut(800);
-//   $('#loader').delay(600).fadeOut(300);
-//   $('#wrap').css('display', 'block');
-// });
-
-// // //10秒たったら強制的にロード画面を非表示
-// $(function(){
-//   setTimeout('stopload()', 10000);
-// })
-
-// function stopload(){
-//   $('#loading').delay(900).fadeOut(1000);
-//   console.log("3秒経過");
-// }
-
-// function stopload(){
-//   $('#wrap').css('display','block');
-//   $('#loading').delay(900).fadeOut(800);
-//   $('#loader').delay(600).fadeOut(300);
-// }
-
 'use strict';
 
-// $(window).on('load', function(){
-//   $('#loading').delay(5000).fadeOut(1000);
-//   console.log("ローディング完了");
-// });
-
-$(document).ready(function() {
+$(function() {
   $('.loading-wise-saying').delay(3000).fadeIn(1500);
   $('.loading-person').delay(4000).fadeIn(1500);
-  // $('#loading').delay(8000).fadeOut(1500);
+  $('#loading').delay(8000).fadeOut(1500);
 });
-
-// $(document).ready(function() {
-//   console.log('筋トレ名言');
-//   let saying = $('.loading-wise-saying');
-//   let person = $('.loading-person');
-//   saying.delay(1000).removeClass('is-hide');
-//   person.delay(1500).removeClass('is-hide');
-//   $('#loading').delay(5000).fadeOut(1500);
-// });

--- a/app/javascript/wise_saying.js
+++ b/app/javascript/wise_saying.js
@@ -35,8 +35,9 @@
 // });
 
 $(document).ready(function() {
-  $('.loading-wise-saying, .loading-person').delay(3000).fadeIn(1500);
-  $('#loading').delay(8000).fadeOut(1500);
+  $('.loading-wise-saying').delay(3000).fadeIn(1500);
+  $('.loading-person').delay(4000).fadeIn(1500);
+  // $('#loading').delay(8000).fadeOut(1500);
 });
 
 // $(document).ready(function() {

--- a/app/javascript/wise_saying.js
+++ b/app/javascript/wise_saying.js
@@ -1,39 +1,49 @@
 // $(function() {
-//   var h = $(window).height();
-  
+//   let h = $(window).height();
+
 //   $('#wrap').css('display','none');
-//   $('#loader-bg ,#loader').height(h).css('display','block');
+//   $('#loading ,#loader').height(h).css('display','block');
 // });
   
 // $(window).load(function () { //全ての読み込みが完了したら実行
-//   $('#loader-bg').delay(900).fadeOut(800);
+//   $('#loading').delay(900).fadeOut(800);
 //   $('#loader').delay(600).fadeOut(300);
 //   $('#wrap').css('display', 'block');
 // });
-  
-// //10秒たったら強制的にロード画面を非表示
+
+// // //10秒たったら強制的にロード画面を非表示
 // $(function(){
-//   setTimeout('stopload()',3000);
-// });
-  
+//   setTimeout('stopload()', 10000);
+// })
+
+// function stopload(){
+//   $('#loading').delay(900).fadeOut(1000);
+//   console.log("3秒経過");
+// }
+
 // function stopload(){
 //   $('#wrap').css('display','block');
-//   $('#loader-bg').delay(900).fadeOut(800);
+//   $('#loading').delay(900).fadeOut(800);
 //   $('#loader').delay(600).fadeOut(300);
 // }
 
 'use strict';
 
-$(window).on('load', function(){
-  $('#loading').delay(900).fadeOut(1000);
-  console.log("ローディング完了");
+// $(window).on('load', function(){
+//   $('#loading').delay(5000).fadeOut(1000);
+//   console.log("ローディング完了");
+// });
+
+$(document).ready(function() {
+  $('.loading-wise-saying, .loading-person').delay(3000).fadeIn(1500);
+  $('#loading').delay(8000).fadeOut(1500);
 });
 
-// $(function(){
-//   setTimeout('stopload()', 10000);
-// })
-
-function stopload(){
-  $('#loading').delay(900).fadeOut(1000);
-  console.log("3秒経過");
-}
+// $(document).ready(function() {
+//   console.log('筋トレ名言');
+//   let saying = $('.loading-wise-saying');
+//   let person = $('.loading-person');
+//   saying.delay(1000).removeClass('is-hide');
+//   person.delay(1500).removeClass('is-hide');
+//   $('#loading').delay(5000).fadeOut(1500);
+// });

--- a/app/views/results/_wise_sayings.html.erb
+++ b/app/views/results/_wise_sayings.html.erb
@@ -1,8 +1,8 @@
 <div id="loader">
   <div id= 'loading-area', class='loading-area pt-6 mt-6' >
     <p class='loading-title p-6'>筋トレ名言</p>
-    <p class='loading-wise-saying is-hide p-6'><%= @word.name %></p>
-    <p class='loading-person is-hide'><%= @word.people %></p>
+    <p class='loading-wise-saying is-hide p-6'><%= word.name %></p>
+    <p class='loading-person is-hide'><%= word.people %></p>
   </div>
   <div class="sink-area">
     <p class="rotation"></p>

--- a/app/views/results/_wise_sayings.html.erb
+++ b/app/views/results/_wise_sayings.html.erb
@@ -1,11 +1,11 @@
 <div id="loader">
   <div id= 'loading-area', class='loading-area pt-6 mt-6' >
     <p class='loading-title p-6'>筋トレ名言</p>
-    <p class='loading-wise-saying is-hide'><%= @word.name %></p>
+    <p class='loading-wise-saying is-hide p-6'><%= @word.name %></p>
     <p class='loading-person is-hide'><%= @word.people %></p>
   </div>
   <div class="sink-area">
-    <%= image_tag 'img-loading.gif', width: "80", height:"80", alt:"Now Loading..." %>
-    <p class='loading-mesaage'>解決策考案中...</p>
+    <p class="rotation"></p>
+    <p class='loading-mesaage pt-6'>解決策考案中...</p>
   </div>
 </div>

--- a/app/views/results/_wise_sayings.html.erb
+++ b/app/views/results/_wise_sayings.html.erb
@@ -1,7 +1,7 @@
 <div id= 'loading-area', class='loading-area pt-6 mt-6' >
   <p class='loading-title p-6'>筋トレ名言</p>
-  <p class='loading-wise-saying'><%= @word.name %></p>
-  <p class='loading-person'><%= @word.people %></p>
   <%= image_tag 'img-loading.gif', width: "80", height:"80", alt:"Now Loading..." %>
   <p class='loading-mesaage'>解決策考案中...</p>
+  <p class='loading-wise-saying is-hide'><%= @word.name %></p>
+  <p class='loading-person is-hide'><%= @word.people %></p>
 </div>

--- a/app/views/results/_wise_sayings.html.erb
+++ b/app/views/results/_wise_sayings.html.erb
@@ -1,7 +1,11 @@
-<div id= 'loading-area', class='loading-area pt-6 mt-6' >
-  <p class='loading-title p-6'>筋トレ名言</p>
-  <%= image_tag 'img-loading.gif', width: "80", height:"80", alt:"Now Loading..." %>
-  <p class='loading-mesaage'>解決策考案中...</p>
-  <p class='loading-wise-saying is-hide'><%= @word.name %></p>
-  <p class='loading-person is-hide'><%= @word.people %></p>
+<div id="loader">
+  <div id= 'loading-area', class='loading-area pt-6 mt-6' >
+    <p class='loading-title p-6'>筋トレ名言</p>
+    <p class='loading-wise-saying is-hide'><%= @word.name %></p>
+    <p class='loading-person is-hide'><%= @word.people %></p>
+  </div>
+  <div class="sink-area">
+    <%= image_tag 'img-loading.gif', width: "80", height:"80", alt:"Now Loading..." %>
+    <p class='loading-mesaage'>解決策考案中...</p>
+  </div>
 </div>

--- a/app/views/results/_wise_sayings.html.erb
+++ b/app/views/results/_wise_sayings.html.erb
@@ -1,5 +1,7 @@
-<div id= 'test', class='red' >
+<div id= 'loading-area', class='loading-area pt-6 mt-6' >
   <p class='loading-title p-6'>筋トレ名言</p>
   <p class='loading-wise-saying'><%= @word.name %></p>
   <p class='loading-person'><%= @word.people %></p>
+  <%= image_tag 'img-loading.gif', width: "80", height:"80", alt:"Now Loading..." %>
+  <p class='loading-mesaage'>解決策考案中...</p>
 </div>

--- a/app/views/results/result.html.erb
+++ b/app/views/results/result.html.erb
@@ -1,29 +1,10 @@
 <div class="p-6">
   <h1 class='result-title'>解決策</h1>
 </div>
-<!--
- 筋トレ名言 
-<div id="loader-bg">
-  <div id="loader">
-    <%= render 'results/wise_sayings' %>
-  </div>
-</div>
-
- 解決策 
-<div id="wrap">
-  <div id='resut_wrapper' class='result' >
-    <%= @result.name %>のお悩みは、<br>
-    <p><%= @result.reason.trouble.name %></p>
-    <p>解決方法は、</p>
-    <h1>筋トレです</h1>
-    <p><%=@result.reason.name%></p>
-  </div>
-</div>
--->
 
 <!-- ローディングページ -->
 <div id="loading">
-  <%= render 'wise_sayings' %>
+  <%= render 'wise_sayings', word: @word %>
 </div>
 
 <!-- 解決策ページ -->
@@ -48,19 +29,16 @@
 <!-- YouTube動画表示エリア -->
 <div class="youtube-videos p-6">
   <div class="youtube-video p-5">
-    <!--<p class='video-title pb-2'><%= @video[0].title %></p>-->
     <%= content_tag 'iframe', nil, width: 500, height: 300, src: "#{@video[0].video}", \
         frameborder: 0, gesture: 'media', allow: 'encrypted-media', allowfullscreen: true %>
   </div>
 
   <div class="youtube-video p-5">
-    <!--<p class='video-title pb-2'><%= @video[1].title %></p>-->
     <%= content_tag 'iframe', nil, width: 500, height: 300, src: "#{@video[1].video}", \
         frameborder: 0, gesture: 'media', allow: 'encrypted-media', allowfullscreen: true %>
   </div>
 
   <div class="youtube-video p-5">
-    <!--<p class='video-title pb-2'><%= @video[2].title %></p>-->
     <%= content_tag 'iframe', nil, width: 500, height: 300, src: "#{@video[2].video}", \
         frameborder: 0, gesture: 'media', allow: 'encrypted-media', allowfullscreen: true %>
   </div>

--- a/app/views/results/result.html.erb
+++ b/app/views/results/result.html.erb
@@ -24,9 +24,7 @@
 <!-- ローディングページ -->
 <div id="loading">
   <div id="loader">
-    <%= render 'results/wise_sayings' %>
-    <%= image_tag 'img-loading.gif', width: "80", height:"80", alt:"Now Loading..." %>
-    <p class='loading-mesaage'>解決策考案中...</p>
+    <%= render 'wise_sayings' %>
   </div>
 </div>
 

--- a/app/views/results/result.html.erb
+++ b/app/views/results/result.html.erb
@@ -23,9 +23,7 @@
 
 <!-- ローディングページ -->
 <div id="loading">
-  <div id="loader">
-    <%= render 'wise_sayings' %>
-  </div>
+  <%= render 'wise_sayings' %>
 </div>
 
 <!-- 解決策ページ -->
@@ -41,7 +39,7 @@
 
     <div class="wise-saying-area pt-6">
       <p class='wise-saying-label'>筋トレ名言</p>
-      <p class='wise-saying' id='wise-saying'><%= @word.name %></p>
+      <p class='wise-saying pl-2 pr-2' id='wise-saying'><%= @word.name %></p>
       <p class='syawing-person' id='syawing-person'><%= @word.people %></p>
     </div>
   </div>


### PR DESCRIPTION
概要
ローディングページのアニメーションを変更

実装内容
- 背景を設定
- 名言と人物名を時間差でフェードインして表示させた
- 「解決考案中」の上にあったアニメーション（gif）を排除して、cssで実装した
- 不要なコメントアウトを削除

確認
[![Image from Gyazo](https://i.gyazo.com/6af62f013d8c43f74d9becf9dc7986d6.gif)](https://gyazo.com/6af62f013d8c43f74d9becf9dc7986d6)