### PR TITLE
YouTube APIで動画を保存できないバグの修正

### DIFF
--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -1,5 +1,5 @@
 class Exercise < ApplicationRecord
-  validates :title, presence: true
+  # validates :title, presence: true
   validates :video, presence: true
   validates :category, presence: true
 end

--- a/db/migrate/20211018063505_remove_title_from_exercises.rb
+++ b/db/migrate/20211018063505_remove_title_from_exercises.rb
@@ -1,0 +1,5 @@
+class RemoveTitleFromExercises < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :exercises, :title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_07_26_113334) do
+ActiveRecord::Schema.define(version: 2021_10_18_063505) do
 
   create_table "exercises", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
-    t.string "title", null: false
     t.string "video", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/lib/tasks/youtube_task.rake
+++ b/lib/tasks/youtube_task.rake
@@ -11,20 +11,17 @@ namespace :youtube_task do
     youtube.key = Rails.application.credentials.youtube[:youtube_api_key]
 
     # 検索ワード
-    # 複数の検索ワードを使って件s買うすることができない
     # 最後のワードだけを使って検索される
-    keywords = %w[筋トレ男性 筋トレ女子 HIIT]
+    keywords = %w[筋トレ男性 筋トレ女子 筋トレ+面白]
 
-    # オプションの指定
-    # 検索ワード、公開日、取得数
-
+    # オプションの指定(検索ワード、公開日、取得数)
     keywords.each do |keyword|
       options = {
         channel_type: 'any',
         # 検索ワード(上記で定義したもの)
         q: keyword,
         # 取得件数
-        max_results: 5,
+        max_results: 15,
         published_after: '2020-01-01T00:00:00Z',
         type: 'video',
         video_duration: 'medium'
@@ -34,12 +31,10 @@ namespace :youtube_task do
       response = youtube.list_searches(:snippet, options)
       # each文で一つずつ取り出す
       response.items.each do |item|
-        video_title = item.snippet.title
         video_id = item.id.video_id
         # 埋め込み用
         video = "https://www.youtube.com/embed/#{video_id}"
-        # 直接ブラウザで視聴する用
-        # video = "https://www.youtube.com/watch?v=#{video_id}"
+        # カテゴリーの付与
         if keyword == '筋トレ男性'
           category = 'man'
         elsif keyword == '筋トレ女子'
@@ -48,12 +43,9 @@ namespace :youtube_task do
           category = 'other'
         end
 
-        exercise = Exercise.new(title: video_title, video: video, category: category)
+        exercise = Exercise.new(video: video, category: category)
         # 保存に失敗したら止めて知らせる
         begin
-          # puts exercise.title
-          # puts exercise.video
-          # puts exercise.category
           exercise.save
         rescue Google::APIClient::TransmissionError => e
           puts e.result.body


### PR DESCRIPTION
概要
YouTube APIで動画を保存できないバグの修正

実装内容
- heroku上でtitleカラムを保存できなかったため、titleカラムを削除
→titleカラムのデータは現在は使ってないので、消しても問題ない
- exerciseモデルのtitleのバリデーションをコメントアウト
- rakeタスクのtitleを保存する処理を削除

確認
rakeタスクを実行して、動画が保存できること