### PR TITLE
MySQLのの文字コードの変更

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,14 +12,14 @@
 
 ActiveRecord::Schema.define(version: 2021_10_18_063505) do
 
-  create_table "exercises", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "exercises", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "video", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "category", null: false
   end
 
-  create_table "reasons", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "reasons", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.bigint "trouble_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -27,7 +27,7 @@ ActiveRecord::Schema.define(version: 2021_10_18_063505) do
     t.index ["trouble_id"], name: "index_reasons_on_trouble_id"
   end
 
-  create_table "results", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "results", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "reason_id", null: false
     t.string "name", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -35,14 +35,14 @@ ActiveRecord::Schema.define(version: 2021_10_18_063505) do
     t.index ["reason_id"], name: "index_results_on_reason_id"
   end
 
-  create_table "troubles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "troubles", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.integer "kind", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "wise_sayings", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "wise_sayings", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "people", null: false
     t.datetime "created_at", precision: 6, null: false


### PR DESCRIPTION
概要
MySQLのの文字コードの変更

実装内容
heroku上でDBのリセットができなかったため、
database.ymlの文字コードの変更

確認
ローカル上では問題なく動作した