### PR TITLE
database.ymlの変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,6 @@ yarn-debug.log*
 
 # Ignore vendor
 /vendor
-/config/database.yml
 /public/uploads
 
 # Ignore local settings

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,0 +1,55 @@
+# MySQL. Versions 5.5.8 and up are supported.
+#
+# Install the MySQL driver
+#   gem install mysql2
+#
+# Ensure the MySQL gem is defined in your Gemfile
+#   gem 'mysql2'
+#
+# And be sure to use new-style password hashing:
+#   https://dev.mysql.com/doc/refman/5.7/en/password-hashing.html
+#
+default: &default
+  adapter: mysql2
+  encoding: utf8mb4
+  charset: utf8mb4
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  username: root
+  password: <%= Rails.application.credentials.mysql[:password] %>
+  socket: /tmp/mysql.sock
+
+development:
+  <<: *default
+  database: mukinator_ver2_development
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test:
+  <<: *default
+  database: mukinator_ver2_test
+
+# As with config/credentials.yml, you never want to store sensitive information,
+# like your database password, in your source code. If your source code is
+# ever seen by anyone, they now have access to your database.
+#
+# Instead, provide the password as a unix environment variable when you boot
+# the app. Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
+# for a full rundown on how to provide these environment variables in a
+# production deployment.
+#
+# On Heroku and other platform providers, you may have a full connection URL
+# available as an environment variable. For example:
+#
+#   DATABASE_URL="mysql2://myuser:mypass@localhost/somedatabase"
+#
+# You can use this database configuration with:
+#
+#   production:
+#     url: <%= ENV['DATABASE_URL'] %>
+#
+production:
+  <<: *default
+  database: mukinator_ver2_production
+  username: mukinator_ver2
+  password: <%= ENV['MUKINATOR_VER2_DATABASE_PASSWORD'] %>


### PR DESCRIPTION
概要
database.ymlを.gitignnoreの管理下から外した

実装内容
- 文字コードの設定
- `.gitignore`から`config/database.yml`を削除

確認
heroku上でDBが作成できた

コメント
database.ymlを.gitignoreに入っていたためherokuに反映されたかったことが原因