### PR TITLE
twitterからのアクセスをトップに限定

### DIFF
--- a/app/views/results/result.html.erb
+++ b/app/views/results/result.html.erb
@@ -63,7 +63,7 @@
     </div>
 
     <div class='twitter-button'>
-      <%= link_to "https://twitter.com/share?&url=https://mukinator.com/results/#{@result.id}&text=【#{@result.reason.trouble.name}】の解決方法がわかりました。&hashtags=MUKINATOR,ムキネイター,筋トレ,筋肉,悩み&lang=ja", title: 'Twitter', target: :_blank, rel: 'noopener noreferrer' do %>
+      <%= link_to "https://twitter.com/share?&url=https://mukinator.com&text=【#{@result.reason.trouble.name}】の解決方法がわかりました。&hashtags=MUKINATOR,ムキネイター,筋トレ,筋肉,悩み&lang=ja", title: 'Twitter', target: :_blank, rel: 'noopener noreferrer' do %>
         <i class="fab fa-twitter share-button"></i>
       <% end %>
     </div>


### PR DESCRIPTION
概要
twitterシェアのリンクを変更

実装内容
変更前
URLをそれぞれの解決策ページにしていた

変更後
twitterからのアクセスは全てトップに行くように変更

確認
twitterシェアリンクが変更され、アクセスするとトップに行くこと